### PR TITLE
Limit pod lock concurrency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "async-mutex": "^0.5.0",
         "dockerode": "^4.0.6",
         "node-vault": "^0.10.2",
+        "p-limit": "^3.1.0",
         "pino": "^9.7.0",
         "systeminformation": "^5.27.0"
       },
@@ -6594,7 +6595,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
       },
@@ -8615,7 +8616,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "async-mutex": "^0.5.0",
     "dockerode": "^4.0.6",
     "node-vault": "^0.10.2",
+    "p-limit": "^3.1.0",
     "pino": "^9.7.0",
     "systeminformation": "^5.27.0"
   }

--- a/src/__tests__/pod-locking.test.ts
+++ b/src/__tests__/pod-locking.test.ts
@@ -1,0 +1,59 @@
+import { lockPods, LOCK_CONCURRENCY } from "../pod-locking";
+import { TTLCache } from "../ttlCache";
+
+jest.mock("../consul", () => ({
+  tryLockPod: jest.fn(),
+}));
+import { tryLockPod } from "../consul";
+const mockTryLockPod = tryLockPod as jest.Mock;
+
+jest.mock("../logger", () => ({
+  logger: {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+describe("lockPods", () => {
+  it("respects concurrency limits while locking pods", async () => {
+    const podEntries = Array.from({ length: 10 }, (_, i) => ({
+      key: `pods/pod${i}`,
+      pod: { name: `pod${i}`, containers: [], maxInstances: 1 },
+    }));
+
+    let active = 0;
+    let maxActive = 0;
+    mockTryLockPod.mockImplementation(
+      async (_consul, _session, _locks, podEntry) => {
+        active++;
+        if (active > maxActive) maxActive = active;
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        active--;
+        return {
+          pod: podEntry.pod,
+          podEntry,
+          lockKey: `lock-${podEntry.pod.name}`,
+        };
+      },
+    );
+
+    const constraintMatcher = {
+      meetsConstraints: jest.fn().mockResolvedValue(true),
+    };
+
+    const locked = await lockPods(
+      podEntries,
+      {} as any,
+      "session",
+      {} as any,
+      new TTLCache<string, string>(1000),
+      constraintMatcher as any,
+    );
+
+    expect(locked).toHaveLength(podEntries.length);
+    expect(mockTryLockPod).toHaveBeenCalledTimes(podEntries.length);
+    expect(maxActive).toBeLessThanOrEqual(LOCK_CONCURRENCY);
+  });
+});


### PR DESCRIPTION
## Summary
- add p-limit dependency
- constrain simultaneous Consul pod locks to 5
- test that concurrency is respected when locking pods

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688c9ce7d304832dab7fc3a66a3f07f9